### PR TITLE
Null collapse for functions and methods

### DIFF
--- a/src/NodeVisitors/NullCoalesceReplacer.php
+++ b/src/NodeVisitors/NullCoalesceReplacer.php
@@ -16,9 +16,20 @@ class NullCoalesceReplacer extends NodeVisitorAbstract
         if (!$node instanceof Coalesce) {
             return;
         }
-
-        $issetCall = new Node\Expr\FuncCall(new Node\Name('isset'), [$node->left]);
-
-        return new Node\Expr\Ternary($issetCall, $node->left, $node->right);
+        switch(true)
+        {
+            case $node->left instanceof Node\Expr\FuncCall:
+            case $node->left instanceof Node\Expr\MethodCall:
+            case $node->left instanceof Node\Expr\StaticCall:
+                $notEmptyCall = new Node\Expr\BooleanNot(new Node\Expr\FuncCall(new Node\Name('empty'), [$node->left]));
+                return new Node\Expr\Ternary($notEmptyCall, $node->left, $node->right);
+            case $node->left instanceof Node\Expr\BinaryOp:
+                $issetCall = new Node\Expr\FuncCall(new Node\Name('isset'), [$node->left->right]);
+                $node->left->right = new Node\Expr\Ternary($issetCall, $node->left->right, $node->right);
+                return $node->left;
+            default:
+                $issetCall = new Node\Expr\FuncCall(new Node\Name('isset'), [$node->left]);
+                return new Node\Expr\Ternary($issetCall, $node->left, $node->right);
+        }
     }
 }

--- a/tests/stubs/converter/it-can-replace-null-coalesce-operators/php5.php
+++ b/tests/stubs/converter/it-can-replace-null-coalesce-operators/php5.php
@@ -1,4 +1,24 @@
 <?php
 
+function test1()
+{
+    return null;
+}
+function test2()
+{
+    return null;
+}
+class Test
+{
+    public function testMethod()
+    {
+        return null;
+    }
+}
+$test = new Test();
 $result = isset($input) ? $input : 'fixed-value';
 $result = isset($input) ? $input : (isset($input2) ? $input2 : $input3);
+$result = !empty(test1()) ? test1() : (!empty(test2()) ? test2() : 0);
+if (null === (isset($input) ? $input : null)) {
+}
+$result = !empty($test->testMethod()) ? $test->testMethod() : 0;

--- a/tests/stubs/converter/it-can-replace-null-coalesce-operators/php7.php
+++ b/tests/stubs/converter/it-can-replace-null-coalesce-operators/php7.php
@@ -1,5 +1,19 @@
 <?php
 
+function test1() {return null;}
+function test2() {return null;}
+
+class Test {public function testMethod() {return null;}}
+
+$test = new Test();
+
 $result = $input ?? 'fixed-value';
 
 $result = $input ?? $input2 ?? $input3;
+
+$result = test1() ?? test2() ?? 0;
+
+if (null === $input ?? null) {
+}
+
+$result = $test->testMethod() ?? 0;


### PR DESCRIPTION
Fail on:
if (5 < $a ?? 3) {}
$result = calcSome() ?? 0;
$result = $calc->some() ?? 0;
$result = Calc::come() ?? 0;
