### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/console": "^2.7|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^5.7",
         "illuminate/filesystem": "~5.2.0|~5.3.0",
         "symfony/process": "^2.7|^3.0"
     },

--- a/tests/ConsoleCommandTest.php
+++ b/tests/ConsoleCommandTest.php
@@ -2,13 +2,14 @@
 
 namespace Spatie\Php7to5\Test;
 
-use Symfony\Component\Process\Process;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 
 /**
  * Class ConsoleCommandTest.
  */
-class ConsoleCommandTest extends \PHPUnit_Framework_TestCase
+class ConsoleCommandTest extends TestCase
 {
     protected $inputFile;
     protected $outputFile;

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -3,9 +3,10 @@
 namespace Spatie\Php7to5\Test;
 
 use Spatie\Php7to5\Converter;
+use PHPUnit\Framework\TestCase;
 use Spatie\Php7to5\Exceptions\InvalidParameter;
 
-class ConverterTest extends \PHPUnit_Framework_TestCase
+class ConverterTest extends TestCase
 {
     /** @test */
     public function it_can_remove_scalar_type_hints()

--- a/tests/DirectoryConverterTest.php
+++ b/tests/DirectoryConverterTest.php
@@ -2,10 +2,11 @@
 
 namespace Spatie\Php7to5\Test;
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
 use Spatie\Php7to5\DirectoryConverter;
 
-class DirectoryConverterTest extends \PHPUnit_Framework_TestCase
+class DirectoryConverterTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md) for compatibility.