### PR TITLE
Overwrite fix

### DIFF
--- a/src/Console/ConvertCommand.php
+++ b/src/Console/ConvertCommand.php
@@ -102,7 +102,10 @@ class ConvertCommand extends Command
         $excludes = $input->getOption('exclude');
         $converter = new DirectoryConverter($source, $extensions, $excludes);
 
-        $this->isDestinationASourceDirectory($source, $destination);
+        if (!$input->getOption('overwrite')) {
+          $this->isDestinationASourceDirectory($source, $destination);
+        }
+
         $this->isDestinationDifferentThanSource($source, $destination);
 
         if (!$input->getOption('copy-all')) {


### PR DESCRIPTION
Option `--overwrite` doesn't work, when source and destination directories are equal.