### PR TITLE
Fixed failed tests for CLI command

### DIFF
--- a/tests/ConsoleCommandTest.php
+++ b/tests/ConsoleCommandTest.php
@@ -237,7 +237,7 @@ class ConsoleCommandTest extends TestCase
      */
     protected function getCommand($inputFile, $outputFile, $options = null)
     {
-        return "./php7to5 convert {$inputFile} {$outputFile} {$options}";
+        return "./php7to5 convert {$inputFile} {$outputFile} {$options} -vv";
     }
 
     /**
@@ -247,7 +247,7 @@ class ConsoleCommandTest extends TestCase
      */
     protected function runCommand($command)
     {
-        $process = new Process($command);
+        $process = new Process($command, dirname(__DIR__));
         $process->run();
 
         return $process;


### PR DESCRIPTION
Hey there!
First of all thanks for the lib.

I've noticed that some tests are failing. So made them working green.

What was done:
* Increased verbosity level for the running command in tests.
* Set explicit working directory for the command runner. Otherwise, it was impossible to run ConsoleCommandTest separately.